### PR TITLE
Fix checks on other systems

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,9 +21,6 @@ jobs:
           - {os: windows-latest, r: '3.6'}
           - {os: macOS-latest, r: '3.6'}
           - {os: macOS-latest, r: 'devel'}
-          - {os: ubuntu-16.04, r: '3.2', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04, r: '3.3', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04, r: '3.4', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.5', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.6', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,11 @@ on:
   push:
     branches:
       - master
+      - check-other-systems
   pull_request:
     branches:
       - master
+      - check-other-systems
 
 name: R-CMD-check
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CourseKataData
 Title: Work With Data From CourseKata Data Science Classes
-Version: 0.1.0
+Version: 1.0.0
 Authors@R: c(
     person(given = "Adam",
            family = "Blake",
@@ -17,7 +17,7 @@ Description: This package is intended to help researchers
 License: GPL-3
 Encoding: UTF-8
 Depends: 
-    R (>= 3.2)
+    R (>= 3.5)
 Imports: 
     magrittr,
     fs,

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -57,7 +57,8 @@ load_data <- function(object, regexp = '.*', class_id = NULL) {
       safe_directories <- fs::path_dir(safe_targets)
 
       # extract to a temporary directory
-      temp_dir <- fs::path_ext_remove(fs::path_file(zip_file)) %>% fs::path_temp()
+      temp_dir_name <- fs::path_ext_remove(fs::path_file(zip_file))
+      temp_dir <- fs::dir_create(fs::path(tempdir(check = TRUE), temp_dir_name))
       purrr::walk2(targets, safe_directories, function(file_name, directory) {
         ex_dir <- fs::path(temp_dir, directory)
         utils::unzip(zip_file, file_name, junkpaths = TRUE, exdir = ex_dir)

--- a/tests/data/supplementary/supplementary_1.csv
+++ b/tests/data/supplementary/supplementary_1.csv
@@ -1,0 +1,2 @@
+student_id,some_variable
+"3bfef3da-164e-41ed-884c-b6ed3e5b9644","supplementary_1"

--- a/tests/data/supplementary/supplementary_2.csv
+++ b/tests/data/supplementary/supplementary_2.csv
@@ -1,0 +1,2 @@
+student_id,some_variable
+"3bfef3da-164e-41ed-884c-b6ed3e5b9644","supplementary_2"

--- a/tests/testthat/test-export.R
+++ b/tests/testthat/test-export.R
@@ -20,7 +20,7 @@ test_that('the converter can swapped out for something custom', {
 
 test_that('list columns are converted to JSON for CSV output', {
   on.exit(try(unlink(test_file, recursive = TRUE, force = TRUE), silent = TRUE))
-  test_file <- fs::file_temp()
+  test_file <- fs::file_temp(tmp_dir = tempdir(check = TRUE))
 
   df <- tibble::tibble(x = list(list(a = 'named'), list(1:3)))
   write.csv(df, test_file)

--- a/tests/testthat/test-export.R
+++ b/tests/testthat/test-export.R
@@ -20,7 +20,7 @@ test_that('the converter can swapped out for something custom', {
 
 test_that('list columns are converted to JSON for CSV output', {
   on.exit(try(unlink(test_file, recursive = TRUE, force = TRUE), silent = TRUE))
-  test_file <- fs::file_temp(tmp_dir = tempdir(check = TRUE))
+  test_file <- fs::file_temp(pattern = 'ckd-write-csv-', tmp_dir = tempdir(check = TRUE))
 
   df <- tibble::tibble(x = list(list(a = 'named'), list(1:3)))
   write.csv(df, test_file)

--- a/tests/testthat/test-load_data.R
+++ b/tests/testthat/test-load_data.R
@@ -48,7 +48,7 @@ make_test_file <- function(ext, make_in = NULL, envir = parent.frame()) {
       make_test_dir(make_in, envir)
     }
 
-  test_file <- fs::file_temp(tmp_dir = make_in, ext = ext)
+  test_file <- fs::file_temp(pattern = 'ckd-', tmp_dir = make_in, ext = ext)
   tryCatch(
     make_file(test_file, envir),
     error = function(e) {
@@ -146,28 +146,28 @@ test_that('a file vector can be filtered by regexp when loading', {
 
 test_that('a file vector can be filtered by class_id when loading', {
   test_df <- df()
-  test_files <- make_test_csvs(test_df, 3, make_in = c(1, 1, 2))
+  test_files <- make_test_csvs(test_df, 3, make_in = c('1', '1', '2'))
 
-  object <- load_data(test_files, class_id = 1)
+  object <- load_data(test_files, class_id = '1')
   expected <- load_data(vctrs::vec_rep(test_df, 2))
   expect_identical(object, expected)
 })
 
 test_that('a file vector can be filtered by multiple class_ids when loading', {
   test_df <- df()
-  test_files <- make_test_csvs(test_df, 3, make_in = c(1, 1, 2))
+  test_files <- make_test_csvs(test_df, 3, make_in = c('a', 'a', 'b'))
 
-  object <- load_data(test_files, class_id = 1:2)
+  object <- load_data(test_files, class_id = c('a', 'b'))
   expected <- load_data(vctrs::vec_rep(test_df, 3))
   expect_identical(object, expected)
 })
 
 test_that('a file vector can be filtered by class_id and regexp when loading', {
   test_df <- df()
-  test_files <- make_test_csvs(test_df, 3, make_in = c(1, 1, 2))
+  test_files <- make_test_csvs(test_df, 3, make_in = c('1', '1', '2'))
 
   regexp <- sprintf('.*%s$', fs::path_file(test_files[[1]]))
-  object <- load_data(test_files, regexp = regexp, class_id = 1)
+  object <- load_data(test_files, regexp = regexp, class_id = '1')
   expected <- load_data(test_df)
   expect_identical(object, expected)
 })
@@ -176,7 +176,7 @@ test_that('a file vector can be filtered by class_id and regexp when loading', {
 # from a directory path
 test_that('directories are loaded like file vectors', {
   test_df <- df()
-  test_file <- make_test_csv(test_df, make_in = 1)
+  test_file <- make_test_csv(test_df, make_in = '1')
   test_dir <- fs::path_dir(test_file)
 
   object <- load_data(test_dir)
@@ -186,18 +186,18 @@ test_that('directories are loaded like file vectors', {
 
 test_that('directories are filtered like file vectors', {
   test_df <- df()
-  test_files <- make_test_csvs(test_df, 3, make_in = c(1, 1, 2))
+  test_files <- make_test_csvs(test_df, 3, make_in = c('1', '1', '2'))
   test_dir <- fs::path_dir(fs::path_dir(test_files[[1]]))
 
   regexp <- sprintf('.*%s$', fs::path_file(test_files[[1]]))
   expected <- load_data(test_df)
   expect_identical(load_data(test_dir, regexp = regexp), expected)
-  expect_identical(load_data(test_dir, class_id = 2), expected)
+  expect_identical(load_data(test_dir, class_id = '2'), expected)
 })
 
 test_that('directory vectors are loaded like file vectors', {
   test_df <- df()
-  test_files <- make_test_csvs(test_df, 3, make_in = c(1, 1, 2))
+  test_files <- make_test_csvs(test_df, 3, make_in = c('1', '1', '2'))
   test_dirs <- unique(fs::path_dir(test_files))
 
   object <- load_data(test_dirs)
@@ -208,7 +208,7 @@ test_that('directory vectors are loaded like file vectors', {
 # from a zip file
 test_that('zips are extracted and loaded like file vectors', {
   test_df <- df()
-  test_zip <- make_test_zip('ckd_test_zip', test_df, 3, c(1, 1, 2))
+  test_zip <- make_test_zip('ckd_test_zip', test_df, 3, c('1', '1', '2'))
 
   object <- load_data(test_zip)
   expected <- load_data(vctrs::vec_rep(test_df, 3))
@@ -217,19 +217,19 @@ test_that('zips are extracted and loaded like file vectors', {
 
 test_that('zips are filtered like file vectors', {
   test_df <- df()
-  test_zip <- make_test_zip('ckd_test_zip', test_df, 3, c(1, 1, 2))
+  test_zip <- make_test_zip('ckd-zip-filter-', test_df, 3, c('1', '1', '2'))
   zip_files <- zip::zip_list(test_zip)$filename
   first_csv <- zip_files[grepl('.*[.]csv$', zip_files)][[1]]
 
   regexp <- sprintf('.*%s$', fs::path_file(first_csv))
   expected <- load_data(test_df)
   expect_identical(load_data(test_zip, regexp = regexp), expected)
-  expect_identical(load_data(test_zip, class_id = 2), expected)
+  expect_identical(load_data(test_zip, class_id = '2'), expected)
 })
 
 test_that('zip vectors are extracted and loaded like file vectors', {
   test_df <- df()
-  test_zip <- make_test_zip('ckd_test_zip', test_df, 1, 1)
+  test_zip <- make_test_zip('ckd-zip-load-', test_df, 1, 'a')
 
   object <- load_data(c(test_zip, test_zip))
   expected <- load_data(vctrs::vec_rep(test_df, 2))
@@ -242,7 +242,7 @@ test_that('it can load a mixed list of directories, files, and zips', {
   test_df <- df()
   test_file <- make_test_csv(test_df, 1)
   test_dir <- fs::path_dir(test_file)
-  test_zip <- make_test_zip('ckd_test_zip', test_df, 1, 1)
+  test_zip <- make_test_zip('ckd-zip-mixed-', test_df, 1, 1)
 
   object <- load_data(c(test_file, test_dir, test_zip))
   expected <- load_data(vctrs::vec_rep(test_df, 3))

--- a/tests/testthat/test-load_data.R
+++ b/tests/testthat/test-load_data.R
@@ -36,12 +36,12 @@ make_test_file <- function(ext, make_in = NULL, envir = parent.frame()) {
   # determine where the file should be created
   test_file <-
     if (is.null(make_in)) {
-      fs::file_temp(ext = ext)
+      fs::file_temp(tmp_dir = tempdir(check = TRUE), ext = ext)
     } else if (fs::is_dir(as.character(make_in))) {
-      fs::file_temp(ext = ext, tmp_dir = make_in)
+      fs::file_temp(tmp_dir = make_in, ext = ext)
     } else {
       # not null, but doesn't exist
-      res <- fs::file_temp(ext = ext, tmp_dir = make_test_dir(make_in, envir))
+      res <- fs::file_temp(tmp_dir = make_test_dir(make_in, envir), ext = ext)
     }
 
   tryCatch(

--- a/tests/testthat/test-load_data.R
+++ b/tests/testthat/test-load_data.R
@@ -144,30 +144,34 @@ test_that('a file vector can be filtered by regexp when loading', {
   expect_identical(object, expected)
 })
 
+# this only fails on win-latest
 test_that('a file vector can be filtered by class_id when loading', {
   test_df <- df()
-  test_files <- make_test_csvs(test_df, 3, make_in = c('1', '1', '2'))
+  add_prefix <- function(x) paste0('filter-id-', x)
+  test_files <- make_test_csvs(test_df, 3, make_in = add_prefix(c(1, 1, 2)))
 
-  object <- load_data(test_files, class_id = '1')
+  object <- load_data(test_files, class_id = add_prefix(1))
   expected <- load_data(vctrs::vec_rep(test_df, 2))
   expect_identical(object, expected)
 })
 
 test_that('a file vector can be filtered by multiple class_ids when loading', {
   test_df <- df()
-  test_files <- make_test_csvs(test_df, 3, make_in = c('a', 'a', 'b'))
+  add_prefix <- function(x) paste0('file-filter-multiple-ids-', x)
+  test_files <- make_test_csvs(test_df, 3, make_in = add_prefix(c(1, 1, 2)))
 
-  object <- load_data(test_files, class_id = c('a', 'b'))
+  object <- load_data(test_files, class_id = add_prefix(1:2))
   expected <- load_data(vctrs::vec_rep(test_df, 3))
   expect_identical(object, expected)
 })
 
 test_that('a file vector can be filtered by class_id and regexp when loading', {
   test_df <- df()
-  test_files <- make_test_csvs(test_df, 3, make_in = c('1', '1', '2'))
+  add_prefix <- function(x) paste0('file-filter-id-and-regexp-', x)
+  test_files <- make_test_csvs(test_df, 3, add_prefix(c(1, 1, 2)))
 
   regexp <- sprintf('.*%s$', fs::path_file(test_files[[1]]))
-  object <- load_data(test_files, regexp = regexp, class_id = '1')
+  object <- load_data(test_files, regexp = regexp, class_id = add_prefix(1))
   expected <- load_data(test_df)
   expect_identical(object, expected)
 })
@@ -176,7 +180,8 @@ test_that('a file vector can be filtered by class_id and regexp when loading', {
 # from a directory path
 test_that('directories are loaded like file vectors', {
   test_df <- df()
-  test_file <- make_test_csv(test_df, make_in = '1')
+  add_prefix <- function(x) paste0('dir-all-', x)
+  test_file <- make_test_csv(test_df, make_in = add_prefix(1))
   test_dir <- fs::path_dir(test_file)
 
   object <- load_data(test_dir)
@@ -186,18 +191,20 @@ test_that('directories are loaded like file vectors', {
 
 test_that('directories are filtered like file vectors', {
   test_df <- df()
-  test_files <- make_test_csvs(test_df, 3, make_in = c('1', '1', '2'))
+  add_prefix <- function(x) paste0('dir-filter-id-and-regexp-', x)
+  test_files <- make_test_csvs(test_df, 3, make_in = add_prefix(c(1, 1, 2)))
   test_dir <- fs::path_dir(fs::path_dir(test_files[[1]]))
 
   regexp <- sprintf('.*%s$', fs::path_file(test_files[[1]]))
   expected <- load_data(test_df)
   expect_identical(load_data(test_dir, regexp = regexp), expected)
-  expect_identical(load_data(test_dir, class_id = '2'), expected)
+  expect_identical(load_data(test_dir, class_id = add_prefix(2)), expected)
 })
 
 test_that('directory vectors are loaded like file vectors', {
   test_df <- df()
-  test_files <- make_test_csvs(test_df, 3, make_in = c('1', '1', '2'))
+  add_prefix <- function(x) paste0('dir-vector-', x)
+  test_files <- make_test_csvs(test_df, 3, make_in = add_prefix(c(1, 1, 2)))
   test_dirs <- unique(fs::path_dir(test_files))
 
   object <- load_data(test_dirs)
@@ -208,7 +215,8 @@ test_that('directory vectors are loaded like file vectors', {
 # from a zip file
 test_that('zips are extracted and loaded like file vectors', {
   test_df <- df()
-  test_zip <- make_test_zip('ckd_test_zip', test_df, 3, c('1', '1', '2'))
+  add_prefix <- function(x) paste0('zip-all-', x)
+  test_zip <- make_test_zip('ckd-zip-all-', test_df, 3, add_prefix(c(1, 1, 2)))
 
   object <- load_data(test_zip)
   expected <- load_data(vctrs::vec_rep(test_df, 3))
@@ -217,19 +225,21 @@ test_that('zips are extracted and loaded like file vectors', {
 
 test_that('zips are filtered like file vectors', {
   test_df <- df()
-  test_zip <- make_test_zip('ckd-zip-filter-', test_df, 3, c('1', '1', '2'))
+  add_prefix <- function(x) paste0('zip-filter-', x)
+  test_zip <- make_test_zip('ckd-zip-filter-', test_df, 3, add_prefix(c(1, 1, 2)))
   zip_files <- zip::zip_list(test_zip)$filename
   first_csv <- zip_files[grepl('.*[.]csv$', zip_files)][[1]]
 
   regexp <- sprintf('.*%s$', fs::path_file(first_csv))
   expected <- load_data(test_df)
   expect_identical(load_data(test_zip, regexp = regexp), expected)
-  expect_identical(load_data(test_zip, class_id = '2'), expected)
+  expect_identical(load_data(test_zip, class_id = add_prefix(2)), expected)
 })
 
 test_that('zip vectors are extracted and loaded like file vectors', {
   test_df <- df()
-  test_zip <- make_test_zip('ckd-zip-load-', test_df, 1, 'a')
+  add_prefix <- function(x) paste0('zip-vector-', x)
+  test_zip <- make_test_zip('ckd-zip-vector-', test_df, 1, add_prefix(1))
 
   object <- load_data(c(test_zip, test_zip))
   expected <- load_data(vctrs::vec_rep(test_df, 2))
@@ -240,9 +250,10 @@ test_that('zip vectors are extracted and loaded like file vectors', {
 # from a mixed list of object types
 test_that('it can load a mixed list of directories, files, and zips', {
   test_df <- df()
-  test_file <- make_test_csv(test_df, 1)
+  add_prefix <- function(x) paste0('zip-mixed-', x)
+  test_file <- make_test_csv(test_df, add_prefix(1))
   test_dir <- fs::path_dir(test_file)
-  test_zip <- make_test_zip('ckd-zip-mixed-', test_df, 1, 1)
+  test_zip <- make_test_zip('ckd-zip-mixed-', test_df, 1, add_prefix(1))
 
   object <- load_data(c(test_file, test_dir, test_zip))
   expected <- load_data(vctrs::vec_rep(test_df, 3))

--- a/tests/testthat/test-process_data.R
+++ b/tests/testthat/test-process_data.R
@@ -1,7 +1,7 @@
 library(fs)
 library(zip)
 
-ex_dir <- path_temp("some_path")
+ex_dir <- fs::path(tempdir(check = TRUE), "coursekdatadata_process_data")
 zip_file <- data_file("zipped.zip")
 unzip(data_file("zipped.zip"), exdir = ex_dir)
 

--- a/tests/testthat/test-process_responses.R
+++ b/tests/testthat/test-process_responses.R
@@ -33,7 +33,7 @@ resp_file_2 <- path(class_dir[[2]], "responses", ext = "csv")
 utils::write.csv(mock_responses_integration, resp_file_1, row.names = FALSE)
 utils::write.csv(mock_responses_integration, resp_file_2, row.names = FALSE)
 
-zip_file <- file_temp(ext = ".zip")
+zip_file <- file_temp(pattern = 'ckd-responses-', ext = ".zip")
 zipr(zip_file, top_dir)
 
 

--- a/tests/testthat/test-process_responses.R
+++ b/tests/testthat/test-process_responses.R
@@ -25,7 +25,7 @@ mock_responses_integration <- data.frame(
 
 mock_integration_processed <- process_responses(mock_responses_integration)
 
-top_dir <- path_temp("data_download")
+top_dir <- path(tempdir(check = TRUE), "data_download")
 class_dir <- dir_create(path(top_dir, "classes", c("class_1", "class_2")))
 
 resp_file_1 <- path(class_dir[[1]], "responses", ext = "csv")

--- a/tests/testthat/test-process_responses.R
+++ b/tests/testthat/test-process_responses.R
@@ -30,8 +30,8 @@ class_dir <- dir_create(path(top_dir, "classes", c("class_1", "class_2")))
 
 resp_file_1 <- path(class_dir[[1]], "responses", ext = "csv")
 resp_file_2 <- path(class_dir[[2]], "responses", ext = "csv")
-write.csv(mock_responses_integration, resp_file_1, row.names = FALSE)
-write.csv(mock_responses_integration, resp_file_2, row.names = FALSE)
+utils::write.csv(mock_responses_integration, resp_file_1, row.names = FALSE)
+utils::write.csv(mock_responses_integration, resp_file_2, row.names = FALSE)
 
 zip_file <- file_temp(ext = ".zip")
 zipr(zip_file, top_dir)


### PR DESCRIPTION
There are some problems with the automated checks on GitHub, i.e. `win-latest` will fail even though that is the system the package was developed on. After some investigation, I think the issue stems from a file permissions error where temp files are unable to be deleted. To work around this, all temp files get a unique prefix --- they may not be cleaned up but they don't interfere with tests.